### PR TITLE
Read from metadata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -52,9 +52,9 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anstyle"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15c4c2c83f81532e5845a733998b6971faca23490340a418e9b72a3ec9de12ea"
+checksum = "b84bf0a05bbb2a83e5eb6fa36bb6e87baa08193c35ff52bbf6b38d8af2890e46"
 
 [[package]]
 name = "async-trait"
@@ -207,9 +207,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.4.2"
+version = "4.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a13b88d2c62ff462f88e4a121f17a82c1af05693a2f192b5c38d14de73c19f6"
+checksum = "84ed82781cea27b43c9b106a979fe450a13a31aab0500595fb3fc06616de08e6"
 dependencies = [
  "clap_builder",
 ]
@@ -580,9 +580,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.147"
+version = "0.2.148"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
+checksum = "9cdc71e17332e86d2e1d38c1f99edcb6288ee11b815fb1a4b049eaa2114d369b"
 
 [[package]]
 name = "linux-raw-sys"
@@ -792,9 +792,9 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.66"
+version = "1.0.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9"
+checksum = "3d433d9f1a3e8c1263d9456598b16fec66f4acc9a74dacffd35c7bb09b3a1328"
 dependencies = [
  "unicode-ident",
 ]
@@ -1027,9 +1027,9 @@ checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
 
 [[package]]
 name = "socket2"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2538b18701741680e0322a2302176d3253a35388e2e62f172f64f4f16605f877"
+checksum = "4031e820eb552adee9295814c0ced9e5cf38ddf1e8b7d566d6de8e2538ea989e"
 dependencies = [
  "libc",
  "windows-sys",
@@ -1037,9 +1037,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.31"
+version = "2.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "718fa2415bcb8d8bd775917a1bf12a7931b6dfa890753378538118181e0cb398"
+checksum = "9caece70c63bfba29ec2fed841a09851b14a235c60010fa4de58089b6c025668"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1122,9 +1122,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.11"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "301abaae475aa91687eb82514b328ab47a211a533026cb25fc3e519b86adfc3c"
+checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
 name = "uuid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "forceps"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["Jacob Parker <blocckba5her@gmail.com>"]
 description = "An easy-to-use async & on-disk database"
 readme = "README.md"

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -180,6 +180,10 @@ impl Cache {
             return self.track_access_for(k).map(|_| val);
         }
 
+        // read the metadata to reduce miss cost, since the metadata DB should generally fit in
+        // memory (and also removes the need to read file metadata for a hit.)
+        let Ok(meta) = self.meta.get_metadata(k) else { return Err(ForcepError::NotFound) };
+
         let file = {
             let path = self.path_from_key(k);
             afs::OpenOptions::new()
@@ -193,8 +197,7 @@ impl Cache {
         };
 
         // create a new buffer based on the estimated size of the file
-        let size_guess = file.metadata().await.map(|x| x.len()).unwrap_or(0);
-        let mut buf = Vec::with_capacity(size_guess as usize);
+        let mut buf = Vec::with_capacity(meta.get_size() as _);
 
         // read the entire file to the buffer
         tokio::io::BufReader::with_capacity(self.opts.rbuff_sz, file)

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -182,7 +182,9 @@ impl Cache {
 
         // read the metadata to reduce miss cost, since the metadata DB should generally fit in
         // memory (and also removes the need to read file metadata for a hit.)
-        let Ok(meta) = self.meta.get_metadata(k) else { return Err(ForcepError::NotFound) };
+        let Ok(meta) = self.meta.get_metadata(k) else {
+            return Err(ForcepError::NotFound);
+        };
 
         let file = {
             let path = self.path_from_key(k);
@@ -239,7 +241,7 @@ impl Cache {
         let value = value.as_ref();
 
         let (tmp, tmp_path) = tempfile(&self.opts.path).await?;
-        // write all data to a temporary file
+        // write all data to a temporary file to allow for atomic replacement and simultaneous reads.
         {
             let mut writer = tokio::io::BufWriter::with_capacity(self.opts.wbuff_sz, tmp);
             writer.write_all(value).await.map_err(ForcepError::Io)?;

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -262,11 +262,14 @@ mod test {
         let db = create_db().unwrap();
         let meta = db.insert_metadata_for(&DATA, &DATA).unwrap();
         // make sure last-modified date is within last second
-        assert_eq!(meta.get_last_modified()
-                       .unwrap()
-                       .elapsed()
-                       .unwrap()
-                       .as_secs(), 0);
+        assert_eq!(
+            meta.get_last_modified()
+                .unwrap()
+                .elapsed()
+                .unwrap()
+                .as_secs(),
+            0
+        );
     }
 
     #[test]

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -262,14 +262,11 @@ mod test {
         let db = create_db().unwrap();
         let meta = db.insert_metadata_for(&DATA, &DATA).unwrap();
         // make sure last-modified date is within last second
-        assert!(
-            meta.get_last_modified()
-                .unwrap()
-                .elapsed()
-                .unwrap()
-                .as_secs()
-                == 0
-        );
+        assert_eq!(meta.get_last_modified()
+                       .unwrap()
+                       .elapsed()
+                       .unwrap()
+                       .as_secs(), 0);
     }
 
     #[test]


### PR DESCRIPTION
This is a bit more controversial of a change. :smile: This trades off miss performance and hit performance.

In our case, when caching elements of a _large_ set with a lower hit rate (e.g., < 50%), a miss can be assumed for most cases. Fetching a miss from the MetaDb costs almost nothing (a few microseconds), so it is the preferred path vs a few ms for a filesystem read. On a hit, we do pay a de-serialization overhead but it also saves the (filesystem) metadata read used to adjust the vector size.

After deploying this change, we saw significantly improved p99 miss performance and approximately the same (if not slightly better) hit performance.